### PR TITLE
Downgrade to netstandard v1.5

### DIFF
--- a/src/Core/Castle.Windsor.Tests/MicroKernelTestCase.cs
+++ b/src/Core/Castle.Windsor.Tests/MicroKernelTestCase.cs
@@ -286,8 +286,8 @@ namespace Castle.Windsor.Tests
 		public void Subsystems_are_case_insensitive()
 		{
 			Assert.NotNull(Kernel.GetSubSystem(SubSystemConstants.ConfigurationStoreKey));
-			Assert.NotNull(Kernel.GetSubSystem(SubSystemConstants.ConfigurationStoreKey.ToLower()));
-			Assert.NotNull(Kernel.GetSubSystem(SubSystemConstants.ConfigurationStoreKey.ToUpper()));
+			Assert.NotNull(Kernel.GetSubSystem(SubSystemConstants.ConfigurationStoreKey.ToLowerInvariant()));
+			Assert.NotNull(Kernel.GetSubSystem(SubSystemConstants.ConfigurationStoreKey.ToUpperInvariant()));
 		}
 
 

--- a/src/Standard/Castle.Core.DynamicProxy/Castle.Core.DynamicProxy.csproj
+++ b/src/Standard/Castle.Core.DynamicProxy/Castle.Core.DynamicProxy.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5</TargetFrameworks>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="CastleKey.snk" />

--- a/src/Standard/Castle.Core/Castle.Core.csproj
+++ b/src/Standard/Castle.Core/Castle.Core.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5</TargetFrameworks>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Version>1.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="CastleKey.snk" />

--- a/src/Standard/Castle.Windsor/Castle.Windsor.csproj
+++ b/src/Standard/Castle.Windsor/Castle.Windsor.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5</TargetFrameworks>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.1" />


### PR DESCRIPTION
Because v1.6 is not supported by full .net framework.
netstandard 1.5 is supported by .net framework 4.6.2